### PR TITLE
Handle gettext_lazy translation objects as strings

### DIFF
--- a/telepath/__init__.py
+++ b/telepath/__init__.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms import MediaDefiningClass
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, Promise
 
 
 DICT_RESERVED_KEYS = ['_type', '_args', '_dict', '_list', '_val', '_id', '_ref']
@@ -282,7 +282,14 @@ class ValueContext:
         if adapter:
             return adapter.pack(obj, self)
 
-        # as fallback, try handling as an iterable
+        # No adapter found; try special-case fallbacks
+
+        if isinstance(obj, Promise) and obj._delegate_text:
+            # object is a lazy translation object; handle as a string, translated to the currently
+            # active locale
+            return StringNode(str(obj))
+
+        # try handling as an iterable
         try:
             items = iter(obj)
         except TypeError:  # obj is not iterable

--- a/telepath/tests.py
+++ b/telepath/tests.py
@@ -1,5 +1,6 @@
 import itertools
 
+from django.utils.translation import activate, gettext_lazy
 from unittest import TestCase
 
 from telepath import Adapter, JSContext, register
@@ -244,6 +245,19 @@ class TestPacking(TestCase):
                 ]
             },
         ])
+
+    def test_lazy_translation_objects(self):
+        yes = Artist(gettext_lazy("Yes"))
+
+        activate('en')
+        ctx = JSContext()
+        result = ctx.pack(yes)
+        self.assertEqual(result, {'_type': 'music.Artist', '_args': ["Yes"]})
+
+        activate('fr')
+        ctx = JSContext()
+        result = ctx.pack(yes)
+        self.assertEqual(result, {'_type': 'music.Artist', '_args': ["Oui"]})
 
 
 class Ark:


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/7059 and https://github.com/wagtail/wagtail/issues/7074

Fix inspired by https://github.com/encode/django-rest-framework/pull/865