### PR TITLE
Add support for packing Python objects to primitive values

### DIFF
--- a/docs/primitive_adapters.md
+++ b/docs/primitive_adapters.md
@@ -1,0 +1,30 @@
+# Packing objects to primitive values
+
+In some cases, rather than writing a custom JavaScript class to correspond to a Python object, it's more appropriate for the JavaScript representation to be a primitive value such as a number or string. For example, Django's [lazy translatable string objects](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#lazy-translations) behave as strings for the most part, but contain custom Python-side logic to ensure that the correct translation for the active locale is chosen. This logic is not relevant to client-side code, and so it is appropriate for the JavaScript code to receive that object as a plain string. (In fact, telepath has built-in recognition for lazy translation strings; however, other Python code may use a similar mechanism and need special treatment.)
+
+For this purpose, telepath provides the classes StringAdapter (for string values) and BaseAdapter (for other simple types) which can be subclassed, and registered in the same way as the adapters we saw previously. For example, if our Python code defines a class for managing capitalised strings:
+
+```python
+class StringLike():
+    def __init__(self, val):
+        self.val = val.upper()
+
+    def __str__(self):
+        return self.val
+```
+
+we can define and register an adapter that will return plain strings when unpacked on the JavaScript side, as follows:
+
+```python
+from telepath import StringAdapter, register
+
+
+class StringLikeAdapter(StringAdapter):
+    def build_node(self, obj, context):
+        return super().build_node(str(obj), context)
+
+
+register(StringLikeAdapter(), StringLike)
+```
+
+Note that the first argument passed to `super().build_node` must be of the correct type - a string for `StringAdapter`, or any JSON-serializable value for `BaseAdapter`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,5 +13,6 @@ nav:
   - Home: index.md
   - Tutorial: tutorial.md
   - Packing external objects: adapters.md
+  - Packing objects to primitive values: primitive_adapters.md
   - API reference: api_reference.md
   - Data format: data_format.md

--- a/telepath/__init__.py
+++ b/telepath/__init__.py
@@ -246,8 +246,8 @@ class AdapterRegistry:
         if len(args) == 2 and not kwargs:
             # called as register(adapter, cls)
             adapter, cls = args
-            if not isinstance(adapter, Adapter):
-                raise TypeError("register expected an Adapter instance, got %r" % adapter)
+            if not isinstance(adapter, BaseAdapter):
+                raise TypeError("register expected a BaseAdapter instance, got %r" % adapter)
 
             self.adapters[cls] = adapter
 
@@ -255,8 +255,8 @@ class AdapterRegistry:
             # called as a class decorator: @register() or @register(adapter=MyAdapter()) -
             # the return value here is the function that will receive the class definition
             adapter = kwargs.get('adapter') or AutoAdapter()
-            if not isinstance(adapter, Adapter):
-                raise TypeError("register expected an Adapter instance, got %r" % adapter)
+            if not isinstance(adapter, BaseAdapter):
+                raise TypeError("register expected a BaseAdapter instance, got %r" % adapter)
 
             def wrapper(cls):
                 # register the class and return it unchanged

--- a/telepath/tests.py
+++ b/telepath/tests.py
@@ -3,7 +3,7 @@ import itertools
 from django.utils.translation import activate, gettext_lazy
 from unittest import TestCase
 
-from telepath import Adapter, JSContext, register
+from telepath import Adapter, JSContext, register, StringAdapter
 
 
 class Artist:
@@ -303,3 +303,32 @@ class TestIDCollisions(TestCase):
                     ]
                 ]
             })
+
+
+class StringLike():
+    def __init__(self, val):
+        self.val = val.upper()
+
+    def __str__(self):
+        return self.val
+
+
+class StringLikeAdapter(StringAdapter):
+    def build_node(self, obj, context):
+        return super().build_node(str(obj), context)
+
+
+register(StringLikeAdapter(), StringLike)
+
+
+class TestPackingToString(TestCase):
+    def test_pack_to_string(self):
+        val = [
+            "real string",
+            StringLike("stringlike"),
+        ]
+
+        ctx = JSContext()
+        result = ctx.pack(val)
+
+        self.assertEqual(result, ["real string", "STRINGLIKE"])


### PR DESCRIPTION
Sometimes it's appropriate for the JS representation of an object to be a plain JSON-serializable value such as a string, rather than a custom-defined object. This would be possible by registering a subclass of StringAdapter / BaseAdapter, except `register` has over-zealous validation that rejects anything other than object-based Adapters. Relax this validation and add some documentation to make this use-case official.