### PR TITLE
Fix check for lazily evaluated objects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 # Current configuration:
-# - django 3.2, python 3.7
+# - django 3.2, python 3.8
 # - django 4.0, python 3.8
 # - django 4.1, python 3.9
 # - django 4.2, python 3.10
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.7"
+          - python: "3.8"
             django: "Django>=3.2,<3.3"
             experimental: false
           - python: "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,11 @@ on:
   pull_request:
 
 # Current configuration:
-# - django 2.2, python 3.6
-# - django 3.0, python 3.7
-# - django 3.1, python 3.8
-# - django 3.2, python 3.9
-# - django 4.0, python 3.10
-# - django 4.1, python 3.10
+# - django 3.2, python 3.7
+# - django 4.0, python 3.8
+# - django 4.1, python 3.9
+# - django 4.2, python 3.10
+# - django main, python 3.11
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -20,24 +19,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.6"
-            django: "Django>=2.2,<2.3"
-            experimental: false
           - python: "3.7"
-            django: "Django>=3.0,<3.1"
-            experimental: false
-          - python: "3.8"
-            django: "Django>=3.1,<3.2"
-            experimental: false
-          - python: "3.9"
             django: "Django>=3.2,<3.3"
             experimental: false
-          - python: "3.10"
+          - python: "3.8"
             django: "Django>=4.0,<4.1"
             experimental: false
-          - python: "3.10"
+          - python: "3.9"
             django: "Django>=4.1,<4.2"
             experimental: false
+          - python: "3.10"
+            django: "Django>=4.2,<4.3"
+            experimental: false
+          - python: "3.11"
+            django: "git+https://github.com/django/django.git@main#egg=Django"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license='BSD',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.5",
+    python_requires=">=3.8",
     extras_require={
         'docs': [
             'mkdocs>=1.1,<1.2',

--- a/telepath/__init__.py
+++ b/telepath/__init__.py
@@ -340,9 +340,9 @@ class ValueContext:
 
         # No adapter found; try special-case fallbacks
 
-        if isinstance(obj, Promise) and obj._delegate_text:
-            # object is a lazy translation object; handle as a string, translated to the currently
-            # active locale
+        if isinstance(obj, Promise):
+            # object is a lazy object (e.g. gettext_lazy result);
+            # handle as a string, translated to the currently active locale
             return StringNode(str(obj))
 
         # try handling as an iterable


### PR DESCRIPTION
`_delegated_text` no longer exists in Django as of https://github.com/django/django/commit/ee36e101e8f8c0acde4bb148b738ab7034e902a0

This is also how Django internally checks for lazily-translated strings (search for `Promise` in its codebase), e.g.

- https://github.com/django/django/blob/531f557f9238b8f2e5032e569cf36f0c05bb4043/django/utils/encoding.py#L31-L33
- https://github.com/django/django/blob/531f557f9238b8f2e5032e569cf36f0c05bb4043/django/utils/encoding.py#L85-L87
- https://github.com/django/django/blob/531f557f9238b8f2e5032e569cf36f0c05bb4043/django/db/models/fields/__init__.py#L315-L317